### PR TITLE
feat(): support extensions

### DIFF
--- a/drive.js
+++ b/drive.js
@@ -14,6 +14,7 @@ async function createCFSDrive(opts) {
   const {
     sparseMetadata = false,
     storeSecretKey = true,
+    extensions = [],
     secretKey = null,
     revision = null,
     storage = null,
@@ -30,6 +31,7 @@ async function createCFSDrive(opts) {
     version: revision,
     latest: Boolean(latest),
     sparse: Boolean(sparse),
+    extensions
   })
 
   // wait for drive to be ready


### PR DESCRIPTION
Fixes #

- Support passing extensions into `hyperdrive` to support this change: https://github.com/mafintosh/hypercore/pull/214